### PR TITLE
Jlou/feat argocd deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 terraform.*
 tfplan*
 *.sh
+!argocd-setup.sh
+!get-password.sh

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 |------|--------|---------|
 | <a name="module_cosmotech-platform"></a> [cosmotech-platform](#module\_cosmotech-platform) | Cosmo-Tech/platform-core/cosmotech | 1.1.3 |
 | <a name="module_cosmotech-prerequisites"></a> [cosmotech-prerequisites](#module\_cosmotech-prerequisites) | ./azure-common-resources | n/a |
+| <a name="module_create_argocd"></a> [create\_argocd](#module\_create\_argocd) | ./create_argocd | n/a |
 
 ## Resources
 
@@ -33,6 +34,18 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_argocd_create_ingress"></a> [argocd\_create\_ingress](#input\_argocd\_create\_ingress) | n/a | `bool` | n/a | yes |
+| <a name="input_argocd_helm_chart"></a> [argocd\_helm\_chart](#input\_argocd\_helm\_chart) | n/a | `string` | n/a | yes |
+| <a name="input_argocd_helm_chart_version"></a> [argocd\_helm\_chart\_version](#input\_argocd\_helm\_chart\_version) | n/a | `string` | n/a | yes |
+| <a name="input_argocd_helm_release_name"></a> [argocd\_helm\_release\_name](#input\_argocd\_helm\_release\_name) | n/a | `string` | n/a | yes |
+| <a name="input_argocd_helm_repo_url"></a> [argocd\_helm\_repo\_url](#input\_argocd\_helm\_repo\_url) | n/a | `string` | n/a | yes |
+| <a name="input_argocd_project"></a> [argocd\_project](#input\_argocd\_project) | n/a | `string` | n/a | yes |
+| <a name="input_argocd_replicas"></a> [argocd\_replicas](#input\_argocd\_replicas) | n/a | `number` | n/a | yes |
+| <a name="input_argocd_repositories"></a> [argocd\_repositories](#input\_argocd\_repositories) | n/a | `list(string)` | n/a | yes |
+| <a name="input_argocd_repository_access_token"></a> [argocd\_repository\_access\_token](#input\_argocd\_repository\_access\_token) | n/a | `string` | n/a | yes |
+| <a name="input_argocd_repository_username"></a> [argocd\_repository\_username](#input\_argocd\_repository\_username) | n/a | `string` | n/a | yes |
+| <a name="input_argocd_setup_job_image_version"></a> [argocd\_setup\_job\_image\_version](#input\_argocd\_setup\_job\_image\_version) | n/a | `string` | n/a | yes |
+| <a name="input_create_argocd"></a> [create\_argocd](#input\_create\_argocd) | n/a | `bool` | n/a | yes |
 | <a name="input_create_keycloak"></a> [create\_keycloak](#input\_create\_keycloak) | n/a | `bool` | n/a | yes |
 | <a name="input_is_bare_metal"></a> [is\_bare\_metal](#input\_is\_bare\_metal) | n/a | `bool` | n/a | yes |
 | <a name="input_owner_list"></a> [owner\_list](#input\_owner\_list) | List of mail addresses for App Registration owners | `list(string)` | n/a | yes |
@@ -42,6 +55,7 @@
 | <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | n/a | `string` | n/a | yes |
 | <a name="input_api_dns_name"></a> [api\_dns\_name](#input\_api\_dns\_name) | n/a | `string` | `""` | no |
 | <a name="input_api_version_path"></a> [api\_version\_path](#input\_api\_version\_path) | The API version path | `string` | `"/"` | no |
+| <a name="input_argocd_namespace"></a> [argocd\_namespace](#input\_argocd\_namespace) | n/a | `string` | `"argocd"` | no |
 | <a name="input_audience"></a> [audience](#input\_audience) | The App Registration audience type | `string` | `"AzureADMultipleOrgs"` | no |
 | <a name="input_cert_manager_helm_release_name"></a> [cert\_manager\_helm\_release\_name](#input\_cert\_manager\_helm\_release\_name) | n/a | `string` | `"cert-manager"` | no |
 | <a name="input_cert_manager_helm_repo_url"></a> [cert\_manager\_helm\_repo\_url](#input\_cert\_manager\_helm\_repo\_url) | n/a | `string` | `"https://charts.jetstack.io"` | no |

--- a/create_argocd/argocd-setup-role.yaml.tpl
+++ b/create_argocd/argocd-setup-role.yaml.tpl
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-setup-role
+  namespace: ${NAMESPACE}
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "secrets", "services"]
+  verbs: ["get", "list", "create", "watch"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]

--- a/create_argocd/argocd-setup-rolebinding.yaml.tpl
+++ b/create_argocd/argocd-setup-rolebinding.yaml.tpl
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-setup-binding
+  namespace: ${NAMESPACE}
+subjects:
+- kind: ServiceAccount
+  name: argocd-setup
+  namespace: ${NAMESPACE}
+roleRef:
+  kind: Role
+  name: argocd-setup-role
+  apiGroup: rbac.authorization.k8s.io

--- a/create_argocd/argocd-setup-serviceaccount.yaml.tpl
+++ b/create_argocd/argocd-setup-serviceaccount.yaml.tpl
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-setup
+  namespace: ${NAMESPACE}

--- a/create_argocd/argocd-setup.sh
+++ b/create_argocd/argocd-setup.sh
@@ -15,12 +15,14 @@ ARGOCD_PASSWORD=$(cat /etc/argocd-initial-admin-secret/password)
 echo "Serveur Argo CD disponible à l'adresse : $ARGOCD_SERVER"
 
 # Login to argo cd
-argocd login $ARGOCD_SERVER --username admin --password $ARGOCD_PASSWORD --insecure
+argocd login $ARGOCD_SERVER --username admin --password $ARGOCD_PASSWORD --insecure --plaintext
+
+echo "logged"
 
 # Add repositories
 if [ -n "$REPOSITORIES" ]; then
     for repo_url in $repos; do
-        argocd repo add $repo_url
+        argocd repo add $repo_url --server $ARGOCD_SERVER
     done
 else
     echo "No repositories to add."
@@ -29,7 +31,7 @@ fi
 # Create project
 if [ -n "$PROJECT" ]; then
 
-    argocd proj create $PROJECT
+    argocd proj create $PROJECT --server $ARGOCD_SERVER
     echo "Project ${PROJECT} created"
 else
     echo "No Project to create"

--- a/create_argocd/argocd-setup.sh
+++ b/create_argocd/argocd-setup.sh
@@ -2,6 +2,8 @@
 NAMESPACE=$1
 PROJECT=$2
 REPOSITORIES=$3
+REPO_USERNAME=$4
+REPO_ACCESS_TOKEN=$5
 
 # Convert repositories into list
 repos=$(echo $REPOSITORIES | tr ',' ' ')
@@ -22,7 +24,7 @@ echo "logged"
 # Add repositories
 if [ -n "$REPOSITORIES" ]; then
     for repo_url in $repos; do
-        argocd repo add $repo_url --server $ARGOCD_SERVER
+        argocd repo add $repo_url --server $ARGOCD_SERVER --username $REPO_USERNAME --password $REPO_ACCESS_TOKEN
     done
 else
     echo "No repositories to add."

--- a/create_argocd/argocd-setup.sh
+++ b/create_argocd/argocd-setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+NAMESPACE=$1
+PROJECT=$2
+REPOSITORIES=$3
+
+# Convert repositories into list
+repos=$(echo $REPOSITORIES | tr ',' ' ')
+
+# Wait for argo cd server
+sleep 30
+
+ARGOCD_SERVER="argocd-server.${NAMESPACE}.svc.cluster.local"
+ARGOCD_PASSWORD=$(cat /etc/argocd-initial-admin-secret/password)
+
+echo "Serveur Argo CD disponible à l'adresse : $ARGOCD_SERVER"
+
+# Login to argo cd
+argocd login $ARGOCD_SERVER --username admin --password $ARGOCD_PASSWORD --insecure
+
+# Add repositories
+if [ -n "$REPOSITORIES" ]; then
+    for repo_url in $repos; do
+        argocd repo add $repo_url
+    done
+else
+    echo "No repositories to add."
+fi
+
+# Create project
+if [ -n "$PROJECT" ]; then
+
+    argocd proj create $PROJECT
+    echo "Project ${PROJECT} created"
+else
+    echo "No Project to create"
+fi

--- a/create_argocd/argocd-setup.sh
+++ b/create_argocd/argocd-setup.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
+set -e
+
 NAMESPACE=$1
 PROJECT=$2
 REPOSITORIES=$3
 REPO_USERNAME=$4
 REPO_ACCESS_TOKEN=$5
+
+# Check if required parameters are provided
+if [ -z "$NAMESPACE" ]; then
+    echo "Error: NAMESPACE is required"
+    exit 1
+fi
 
 # Convert repositories into list
 repos=$(echo $REPOSITORIES | tr ',' ' ')
@@ -12,19 +20,42 @@ repos=$(echo $REPOSITORIES | tr ',' ' ')
 sleep 30
 
 ARGOCD_SERVER="argocd-server.${NAMESPACE}.svc.cluster.local"
-ARGOCD_PASSWORD=$(cat /etc/argocd-initial-admin-secret/password)
+ARGOCD_PASSWORD_FILE="/etc/argocd-initial-admin-secret/password"
 
-echo "Serveur Argo CD disponible à l'adresse : $ARGOCD_SERVER"
+if [ ! -f "$ARGOCD_PASSWORD_FILE" ]; then
+    echo "Error: ArgoCD password file not found"
+    exit 1
+fi
+
+ARGOCD_PASSWORD=$(cat $ARGOCD_PASSWORD_FILE)
+
+if [ -z "$ARGOCD_PASSWORD" ]; then
+    echo "Error: ArgoCD password is empty"
+    exit 1
+fi
+
+echo "ArgoCD Server available at: $ARGOCD_SERVER"
 
 # Login to argo cd
-argocd login $ARGOCD_SERVER --username admin --password $ARGOCD_PASSWORD --insecure --plaintext
+if ! argocd login $ARGOCD_SERVER --username admin --password $ARGOCD_PASSWORD --insecure --plaintext; then
+    echo "Error: Failed to log in to ArgoCD"
+    exit 1
+fi
 
-echo "logged"
+echo "Logged in successfully"
 
 # Add repositories
 if [ -n "$REPOSITORIES" ]; then
+    if [ -z "$REPO_USERNAME" ] || [ -z "$REPO_ACCESS_TOKEN" ]; then
+        echo "Error: Repository username and access token are required when repositories are specified"
+        exit 1
+    fi
     for repo_url in $repos; do
-        argocd repo add $repo_url --server $ARGOCD_SERVER --username $REPO_USERNAME --password $REPO_ACCESS_TOKEN
+        if ! argocd repo add $repo_url --server $ARGOCD_SERVER --username $REPO_USERNAME --password $REPO_ACCESS_TOKEN; then
+            echo "Error: Failed to add repository $repo_url"
+            exit 1
+        fi
+        echo "Added repository: $repo_url"
     done
 else
     echo "No repositories to add."
@@ -32,9 +63,13 @@ fi
 
 # Create project
 if [ -n "$PROJECT" ]; then
-
-    argocd proj create $PROJECT --server $ARGOCD_SERVER
-    echo "Project ${PROJECT} created"
+    if ! argocd proj create $PROJECT --server $ARGOCD_SERVER; then
+        echo "Error: Failed to create project $PROJECT"
+        exit 1
+    fi
+    echo "Project ${PROJECT} created successfully"
 else
     echo "No Project to create"
 fi
+
+echo "Setup completed successfully"

--- a/create_argocd/get-password.sh
+++ b/create_argocd/get-password.sh
@@ -1,7 +1,28 @@
 #!/bin/bash
+set -e
 
 namespace=$1
 secret_name="argocd-initial-admin-secret"
 
+# Check if namespace is provided
+if [ -z "$namespace" ]; then
+    echo "Error: Namespace is required"
+    exit 1
+fi
+
+# Check if the secret exists
+if ! kubectl get secret -n $namespace $secret_name &> /dev/null; then
+    echo "Error: Secret $secret_name not found in namespace $namespace"
+    exit 1
+fi
+
 # Get the initial admin password
 password=$(kubectl -n $namespace get secret $secret_name -o jsonpath="{.data.password}" | base64 --decode)
+
+# Check if password is empty
+if [ -z "$password" ]; then
+    echo "Error: Failed to retrieve password from secret"
+    exit 1
+fi
+
+echo "Password retrieved successfully"

--- a/create_argocd/get-password.sh
+++ b/create_argocd/get-password.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+namespace=$1
+secret_name="argocd-initial-admin-secret"
+
+# Get the initial admin password
+password=$(kubectl -n $namespace get secret $secret_name -o jsonpath="{.data.password}" | base64 --decode)

--- a/create_argocd/get-password.sh
+++ b/create_argocd/get-password.sh
@@ -10,19 +10,7 @@ if [ -z "$namespace" ]; then
     exit 1
 fi
 
-# Check if the secret exists
-if ! kubectl get secret -n $namespace $secret_name &> /dev/null; then
-    echo "Error: Secret $secret_name not found in namespace $namespace"
-    exit 1
-fi
-
 # Get the initial admin password
 password=$(kubectl -n $namespace get secret $secret_name -o jsonpath="{.data.password}" | base64 --decode)
-
-# Check if password is empty
-if [ -z "$password" ]; then
-    echo "Error: Failed to retrieve password from secret"
-    exit 1
-fi
 
 echo "Password retrieved successfully"

--- a/create_argocd/main.tf
+++ b/create_argocd/main.tf
@@ -133,7 +133,7 @@ resource "kubernetes_job" "argocd_setup" {
         service_account_name = "argocd-setup"
         container {
           name  = "setup-argocd"
-          image = "argoproj/argocd:v2.0.5"
+          image = "argoproj/argocd:${var.argocd_setup_job_image_version}"
           command = ["/bin/sh", "/scripts/setup.sh", var.namespace, var.argocd_project, join(",", var.argocd_repositories), var.argocd_repository_username, var.argocd_repository_access_token]
 
           volume_mount {

--- a/create_argocd/main.tf
+++ b/create_argocd/main.tf
@@ -1,0 +1,186 @@
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "2.0.4"
+    }
+  }
+}
+
+locals {
+  values_argocd = {
+    "REPLICAS"              = var.replicas
+    "NAMESPACE"             = var.namespace
+    "CREATE_INGRESS"        = var.create_ingress
+    }
+  instance_name = "${var.helm_release_name}"
+}
+
+resource "kubernetes_namespace" "argocd_namespace" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "helm_release" "argocd" {
+  name       = local.instance_name
+  repository = var.helm_repo_url
+  chart      = var.helm_chart
+  version    = var.helm_chart_version
+  namespace  = var.namespace
+
+  reuse_values = true
+  timeout      = 600
+
+  values = [
+    templatefile("${path.module}/values.yaml", local.values_argocd)
+  ]
+}
+
+# RBAC
+resource "kubernetes_manifest" "argocd_setup_serviceaccount" {
+  manifest = yamldecode(templatefile("${path.module}/argocd-setup-serviceaccount.yaml.tpl", 
+    local.values_argocd
+  ))
+}
+
+resource "kubernetes_manifest" "argocd_setup_role" {
+  manifest = yamldecode(templatefile("${path.module}/argocd-setup-role.yaml.tpl",
+    local.values_argocd
+  ))
+}
+
+resource "kubernetes_manifest" "argocd_setup_rolebinding" {
+  manifest = yamldecode(templatefile("${path.module}/argocd-setup-rolebinding.yaml.tpl",
+    local.values_argocd
+  ))
+}
+
+# ------------- GET ARGOCD PASSWORD ------------ #
+
+resource "kubernetes_config_map" "get_password_script" {
+  metadata {
+    name      = "get-password-script"
+    namespace = var.namespace
+  }
+
+  data = {
+    "get-password.sh" = file("${path.module}/get-password.sh")
+  }
+}
+
+resource "kubernetes_job" "get_argocd_password" {
+  metadata {
+    name      = "get-argocd-password-job"
+    namespace = var.namespace
+  }
+
+  spec {
+    template {
+      metadata {
+        name = "get-argocd-password-job"
+      }
+
+      spec {
+        restart_policy = "OnFailure"
+        service_account_name = "argocd-setup"
+        container {
+          name  = "get-password"
+          image = "bitnami/kubectl:latest"
+          command = ["/bin/sh", "/scripts/get-password.sh", var.namespace]
+
+          volume_mount {
+            name       = "scripts"
+            mount_path = "/scripts/get-password.sh"
+            sub_path   = "get-password.sh"
+          }
+        }
+
+        volume {
+          name = "scripts"
+
+          config_map {
+            name = kubernetes_config_map.get_password_script.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [helm_release.argocd]
+}
+
+# ------------- CONFIGURE ARGOCD ------------ #
+
+resource "kubernetes_config_map" "argocd_script" {
+  metadata {
+    name      = "argocd-setup-script"
+    namespace = var.namespace
+  }
+
+  data = {
+    "setup.sh" = file("${path.module}/argocd-setup.sh")
+  }
+  depends_on = [ helm_release.argocd ]
+}
+
+resource "kubernetes_job" "argocd_setup" {
+  metadata {
+    name      = "argocd-setup-job"
+    namespace = var.namespace
+  }
+
+  spec {
+    template {
+      metadata {
+        name = "argocd-setup-job"
+      }
+
+      spec {
+        restart_policy = "OnFailure"
+        service_account_name = "argocd-setup"
+        container {
+          name  = "setup-argocd"
+          image = "argoproj/argocd:v2.0.5"
+          command = ["/bin/sh", "/scripts/setup.sh", var.namespace, var.argocd_project, join(",", var.argocd_repositories)]
+
+          volume_mount {
+            name       = "scripts"
+            mount_path = "/scripts/setup.sh"
+            sub_path   = "setup.sh"
+          }
+          volume_mount {
+            name       = "argocd-initial-admin-secret"
+            mount_path = "/etc/argocd-initial-admin-secret"
+            read_only  = true
+          }
+        }
+
+        volume {
+          name = "scripts"
+
+          config_map {
+            name = kubernetes_config_map.argocd_script.metadata[0].name
+          }
+        }
+
+        volume {
+          name = "argocd-initial-admin-secret"
+
+          secret {
+            secret_name = "argocd-initial-admin-secret"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_job.get_argocd_password,
+    helm_release.argocd, 
+    kubernetes_config_map.argocd_script,
+    kubernetes_manifest.argocd_setup_role,
+    kubernetes_manifest.argocd_setup_rolebinding,
+    kubernetes_manifest.argocd_setup_serviceaccount
+  ]
+}

--- a/create_argocd/main.tf
+++ b/create_argocd/main.tf
@@ -12,6 +12,7 @@ locals {
     "REPLICAS"              = var.replicas
     "NAMESPACE"             = var.namespace
     "CREATE_INGRESS"        = var.create_ingress
+    "ARGOCD_DNS_NAME"       = var.argocd_dns_name
     }
   instance_name = "${var.helm_release_name}"
 }

--- a/create_argocd/main.tf
+++ b/create_argocd/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    kubectl = {
-      source  = "alekc/kubectl"
-      version = "2.0.4"
-    }
-  }
-}
-
 locals {
   values_argocd = {
     "REPLICAS"              = var.replicas

--- a/create_argocd/main.tf
+++ b/create_argocd/main.tf
@@ -134,7 +134,7 @@ resource "kubernetes_job" "argocd_setup" {
         container {
           name  = "setup-argocd"
           image = "argoproj/argocd:v2.0.5"
-          command = ["/bin/sh", "/scripts/setup.sh", var.namespace, var.argocd_project, join(",", var.argocd_repositories)]
+          command = ["/bin/sh", "/scripts/setup.sh", var.namespace, var.argocd_project, join(",", var.argocd_repositories), var.argocd_repository_username, var.argocd_repository_access_token]
 
           volume_mount {
             name       = "scripts"

--- a/create_argocd/values.yaml
+++ b/create_argocd/values.yaml
@@ -9,45 +9,23 @@ server:
       memory: 256Mi
   ingress:
     enabled: ${CREATE_INGRESS}
-    annotations: {}
-    ingressClassName: ""
-    hostname: ""
-    path: /
+    ingressClassName: "nginx"
+    extraHosts:
+      - name: ${ARGOCD_DNS_NAME}
+        path: /argocd
     pathType: Prefix
-    tls: false
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
 
 configs:
-# rbac:
-#     # -- Create the argocd-rbac-cm configmap with ([Argo CD RBAC policy]) definitions.
-#     # If false, it is expected the configmap will be created by something else.
-#     # Argo CD will not work if there is no configmap created with the name above.
-#   create: true
-
-#     # -- Annotations to be added to argocd-rbac-cm configmap
-#   annotations: {}
-
-#     # -- The name of the default role which Argo CD will falls back to, when authorizing API requests (optional).
-#     # If omitted or empty, users may be still be able to login, but will see no apps, projects, etc...
-#   policy.default: ''
-
-#     # -- File containing user-defined policies and role definitions.
-#     # @default -- `''` (See [values.yaml])
-#   policy.csv: ''
-#     # Policy rules are in the form:
-#     #  p, subject, resource, action, object, effect
-#     # Role definitions and bindings are in the form:
-#     #  g, subject, inherited-subject
-#     # policy.csv: |
-#     #   p, role:org-admin, applications, *, */*, allow
-#     #   p, role:org-admin, clusters, get, *, allow
-#     #   p, role:org-admin, repositories, *, *, allow
-#     #   p, role:org-admin, logs, get, *, allow
-#     #   p, role:org-admin, exec, create, */*, allow
-#     #   g, your-github-org:your-team, role:org-admin
-
-#     # -- OIDC scopes to examine during rbac enforcement (in addition to `sub` scope).
-#     # The scope value can be a string, or a list of strings.
-#   scopes: "[groups]"
-
-#     # -- Matcher function for Casbin, `glob` for glob matcher and `regex` for regex matcher.
-#   policy.matchMode: "glob"
+  params:
+    server.insecure: true
+    server.rootpath: "/argocd"
+    server.basehref: "/argocd"

--- a/create_argocd/values.yaml
+++ b/create_argocd/values.yaml
@@ -1,0 +1,53 @@
+server:
+  replicas: ${REPLICAS}
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
+  ingress:
+    enabled: ${CREATE_INGRESS}
+    annotations: {}
+    ingressClassName: ""
+    hostname: ""
+    path: /
+    pathType: Prefix
+    tls: false
+
+configs:
+# rbac:
+#     # -- Create the argocd-rbac-cm configmap with ([Argo CD RBAC policy]) definitions.
+#     # If false, it is expected the configmap will be created by something else.
+#     # Argo CD will not work if there is no configmap created with the name above.
+#   create: true
+
+#     # -- Annotations to be added to argocd-rbac-cm configmap
+#   annotations: {}
+
+#     # -- The name of the default role which Argo CD will falls back to, when authorizing API requests (optional).
+#     # If omitted or empty, users may be still be able to login, but will see no apps, projects, etc...
+#   policy.default: ''
+
+#     # -- File containing user-defined policies and role definitions.
+#     # @default -- `''` (See [values.yaml])
+#   policy.csv: ''
+#     # Policy rules are in the form:
+#     #  p, subject, resource, action, object, effect
+#     # Role definitions and bindings are in the form:
+#     #  g, subject, inherited-subject
+#     # policy.csv: |
+#     #   p, role:org-admin, applications, *, */*, allow
+#     #   p, role:org-admin, clusters, get, *, allow
+#     #   p, role:org-admin, repositories, *, *, allow
+#     #   p, role:org-admin, logs, get, *, allow
+#     #   p, role:org-admin, exec, create, */*, allow
+#     #   g, your-github-org:your-team, role:org-admin
+
+#     # -- OIDC scopes to examine during rbac enforcement (in addition to `sub` scope).
+#     # The scope value can be a string, or a list of strings.
+#   scopes: "[groups]"
+
+#     # -- Matcher function for Casbin, `glob` for glob matcher and `regex` for regex matcher.
+#   policy.matchMode: "glob"

--- a/create_argocd/variables.tf
+++ b/create_argocd/variables.tf
@@ -38,3 +38,13 @@ variable "argocd_repositories" {
 variable "argocd_dns_name" {
   type = string
 }
+
+variable "argocd_repository_username" {
+  type = string
+  sensitive = true
+}
+
+variable "argocd_repository_access_token" {
+  type = string
+  sensitive = true
+}

--- a/create_argocd/variables.tf
+++ b/create_argocd/variables.tf
@@ -48,3 +48,7 @@ variable "argocd_repository_access_token" {
   type = string
   sensitive = true
 }
+
+variable "argocd_setup_job_image_version" {
+  type = string
+}

--- a/create_argocd/variables.tf
+++ b/create_argocd/variables.tf
@@ -1,0 +1,36 @@
+variable "namespace" {
+  type = string
+  default = "argocd"
+}
+
+variable "helm_repo_url" {
+  type    = string
+}
+
+variable "helm_chart" {
+  type    = string
+}
+
+variable "helm_chart_version" {
+  type    = string
+}
+
+variable "helm_release_name" {
+  type    = string
+}
+
+variable "replicas" {
+    type = number
+}
+
+variable "create_ingress" {
+  type = bool
+}
+
+variable "argocd_project" {
+  type = string
+}
+
+variable "argocd_repositories" {
+  type = list(string)
+}

--- a/create_argocd/variables.tf
+++ b/create_argocd/variables.tf
@@ -34,3 +34,7 @@ variable "argocd_project" {
 variable "argocd_repositories" {
   type = list(string)
 }
+
+variable "argocd_dns_name" {
+  type = string
+}

--- a/modules.tf
+++ b/modules.tf
@@ -151,14 +151,16 @@ module "create_argocd" {
 
   count = var.create_argocd ? 1 : 0
 
-  namespace               = var.argocd_namespace
-  helm_repo_url           = var.argocd_helm_repo_url
-  helm_chart              = var.argocd_helm_chart
-  helm_chart_version      = var.argocd_helm_chart_version
-  helm_release_name       = var.argocd_helm_release_name
-  replicas                = var.argocd_replicas
-  create_ingress          = var.argocd_create_ingress
-  argocd_project          = var.argocd_project
-  argocd_repositories     = var.argocd_repositories
-  argocd_dns_name         = var.api_dns_name
+  namespace                      = var.argocd_namespace
+  helm_repo_url                  = var.argocd_helm_repo_url
+  helm_chart                     = var.argocd_helm_chart
+  helm_chart_version             = var.argocd_helm_chart_version
+  helm_release_name              = var.argocd_helm_release_name
+  replicas                       = var.argocd_replicas
+  create_ingress                 = var.argocd_create_ingress
+  argocd_project                 = var.argocd_project
+  argocd_repositories            = var.argocd_repositories
+  argocd_repository_username     = var.argocd_repository_username
+  argocd_repository_access_token = var.argocd_repository_access_token
+  argocd_dns_name                = var.api_dns_name
 }

--- a/modules.tf
+++ b/modules.tf
@@ -163,4 +163,5 @@ module "create_argocd" {
   argocd_repository_username     = var.argocd_repository_username
   argocd_repository_access_token = var.argocd_repository_access_token
   argocd_dns_name                = var.api_dns_name
+  argocd_setup_job_image_version = var.argocd_setup_job_image_version
 }

--- a/modules.tf
+++ b/modules.tf
@@ -160,4 +160,5 @@ module "create_argocd" {
   create_ingress          = var.argocd_create_ingress
   argocd_project          = var.argocd_project
   argocd_repositories     = var.argocd_repositories
+  argocd_dns_name         = var.api_dns_name
 }

--- a/modules.tf
+++ b/modules.tf
@@ -145,3 +145,19 @@ module "cosmotech-platform" {
   prom_cpu_mem_request          = var.prom_cpu_mem_request
 
 }
+
+module "create_argocd" {
+  source = "./create_argocd"
+
+  count = var.create_argocd ? 1 : 0
+
+  namespace               = var.argocd_namespace
+  helm_repo_url           = var.argocd_helm_repo_url
+  helm_chart              = var.argocd_helm_chart
+  helm_chart_version      = var.argocd_helm_chart_version
+  helm_release_name       = var.argocd_helm_release_name
+  replicas                = var.argocd_replicas
+  create_ingress          = var.argocd_create_ingress
+  argocd_project          = var.argocd_project
+  argocd_repositories     = var.argocd_repositories
+}

--- a/variables.argocd.tf
+++ b/variables.argocd.tf
@@ -1,0 +1,40 @@
+variable "create_argocd" {
+  type = bool
+}
+
+variable "argocd_namespace" {
+  type = string
+  default = "argocd"
+}
+
+variable "argocd_helm_repo_url" {
+  type    = string
+}
+
+variable "argocd_helm_chart" {
+  type    = string
+}
+
+variable "argocd_helm_chart_version" {
+  type    = string
+}
+
+variable "argocd_helm_release_name" {
+  type    = string
+}
+
+variable "argocd_replicas" {
+    type = number
+}
+
+variable "argocd_create_ingress" {
+  type = bool
+}
+
+variable "argocd_project" {
+  type = string
+}
+
+variable "argocd_repositories" {
+  type = list(string)
+}

--- a/variables.argocd.tf
+++ b/variables.argocd.tf
@@ -48,3 +48,7 @@ variable "argocd_repository_access_token" {
   type = string
   sensitive = true
 }
+
+variable "argocd_setup_job_image_version" {
+  type = string
+}

--- a/variables.argocd.tf
+++ b/variables.argocd.tf
@@ -38,3 +38,13 @@ variable "argocd_project" {
 variable "argocd_repositories" {
   type = list(string)
 }
+
+variable "argocd_repository_username" {
+  type = string
+  sensitive = true
+}
+
+variable "argocd_repository_access_token" {
+  type = string
+  sensitive = true
+}


### PR DESCRIPTION
ArgoCD est déployé sur un namespace `argocd`.

La variable `argocd_create_ingress` de type bool permet d’exposer le service sur `api_dns_name`/argocd.

La variable `argocd_project `permet d'ajouter un project.

La variable `argocd_repositories` de type `list(string)` permet d’ajouter des repositories.
Les variables `argocd_repository_username` et `argocd_repository_access_token` permettent de fournir les identifiants pour l'ajout de repos privés.
 
Ces deux ajouts sont réalisés par un kubernetes job.